### PR TITLE
Increase publication thumbnail size to 150px and larger text

### DIFF
--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -257,9 +257,9 @@
 
 .publication-item__image {
   flex-shrink: 0;
-  width: 100px;
-  max-width: 100px;
-  margin-right: 1.2em;
+  width: 150px;
+  max-width: 150px;
+  margin-right: 1.5em;
   margin-bottom: 0;
 
   @media (max-width: $small - 1) {
@@ -285,33 +285,33 @@
 }
 
 .publication-item__title {
-  font-size: $type-size-5;
+  font-size: $type-size-4;
   margin-bottom: 0.5em;
   line-height: 1.3;
 }
 
 .publication-item__authors {
-  font-size: $type-size-6;
+  font-size: $type-size-5;
   margin-bottom: 0.3em;
   line-height: 1.4;
   color: mix(#fff, $gray, 40%);
 }
 
 .publication-item__venue {
-  font-size: $type-size-6;
+  font-size: $type-size-5;
   margin-bottom: 0.5em;
   color: mix(#fff, $gray, 30%);
 }
 
 .publication-item__excerpt {
-  font-size: $type-size-6;
+  font-size: $type-size-5;
   margin-bottom: 0.7em;
   line-height: 1.5;
   color: mix(#fff, $text-color, 20%);
 }
 
 .publication-item__links {
-  font-size: $type-size-6;
+  font-size: $type-size-5;
 
   a {
     margin-right: 0.8em;


### PR DESCRIPTION
- Changed image width from 100px to 150px for better visibility
- Increased title font size (type-size-4)
- Increased all body text sizes (authors, venue, excerpt, links to type-size-5)
- Adjusted margin for better spacing