### PR TITLE
Make publication images clickable with lightbox functionality

### DIFF
--- a/_includes/publication-single.html
+++ b/_includes/publication-single.html
@@ -3,7 +3,9 @@
 <div class="publication-item">
   {% if include.post.teaser %}
   <div class="publication-item__image">
-    <img src="{{ include.post.teaser | prepend: '/images/' | prepend: base_path }}" alt="{{ include.post.title }}">
+    <a href="{{ include.post.teaser | prepend: '/images/' | prepend: base_path }}">
+      <img src="{{ include.post.teaser | prepend: '/images/' | prepend: base_path }}" alt="{{ include.post.title }}">
+    </a>
   </div>
   {% endif %}
 

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -280,6 +280,12 @@
     border-radius: $border-radius;
     border: 1px solid $border-color;
     box-shadow: 0 2px 4px rgba(#000, 0.1);
+    cursor: pointer;
+    transition: opacity 0.2s ease-in-out;
+
+    &:hover {
+      opacity: 0.8;
+    }
   }
 }
 


### PR DESCRIPTION
- Wrap publication images in links to enable lightbox view
- Add pointer cursor and hover effect to indicate clickability
- Images will now open in a larger view when clicked