### PR TITLE
Update VeriCoT to ICLR 2026 and refresh news section

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -25,6 +25,9 @@ I have completed MS (Research) in Computational Science from IIT Madras, India. 
 Aside from work, I like to hike, cook, paint, and [photograph](https://www.instagram.com/a.thing.of.art/).
 
 ## News
+- **[Jan 2026]** VeriCoT accepted to ICLR!
+- **[Jan 2026]** New paper on kernel code optimization out on arxiv!
+- **[Dec 2025]** Serverless open source model reinforcement finetuning (RFT) launched on AWS SageMaker!
 - **[Mar 2025]** Paper on reasoning distillation out on arxiv!
 - **[Jan 2025]** AgentOccam accepted to ICLR 2025!
 - **[Sep 2024]** Paper on Risk Averse RLHF accepted to Neurips 2024!
@@ -32,10 +35,5 @@ Aside from work, I like to hike, cook, paint, and [photograph](https://www.insta
 - **[Aug 2024]** Joined Amazon Web Services (AWS) as an Applied Scientist!
 - **[Aug 2023]** Paper on Safe distributed OCO accepted to TMLR!
 - **[May 2023]** Back in Seattle for an Applied Scientist intern at Amazon!
-- **[Apr 2023]** Accepted to IJCAI 2023 Doctoral Consortium!
-- **[Feb 2023]** New paper on Safe distributed OCO out on arxiv! 
-- **[Feb 2023]** Gave an invited talk on 'Adaptivity and safety in sequential decision making' at Rice University! 
-- **[Sep 2022]** Paper on meta-RL in sparse reward environments accepted to NeurIPS 2022! 
-- **[Aug 2022]** Spent a wonderful summer in Seattle as an Applied Scientist intern at Amazon! 
-- **[Dec 2021]** Paper on Safe online convex optimization accepted to AAAI 2022! 
+- **[Apr 2023]** Accepted to IJCAI 2023 Doctoral Consortium! 
 

--- a/_publications/2025-vericot.md
+++ b/_publications/2025-vericot.md
@@ -4,9 +4,9 @@ collection: publications
 permalink: /publication/2025-vericot
 excerpt: 'Combines neural and symbolic methods to validate chain-of-thought reasoning through logical consistency verification.'
 date: 2025-01-01
-venue: 'arXiv preprint'
+venue: 'ICLR 2026'
 paperurl: 'https://arxiv.org/abs/2511.04662'
-citation: 'Yu Feng, Nathaniel Weir, Kaj Bostrom, Sam Bayless, Darion Cassel, Sapana Chaudhary, Benjamin Kiesl-Reiter, Huzefa Rangwala. (2025). VeriCoT: Neuro-symbolic Chain-of-Thought Validation via Logical Consistency Checks. arXiv preprint.'
+citation: 'Yu Feng, Nathaniel Weir, Kaj Bostrom, Sam Bayless, Darion Cassel, Sapana Chaudhary, Benjamin Kiesl-Reiter, Huzefa Rangwala. (2026). VeriCoT: Neuro-symbolic Chain-of-Thought Validation via Logical Consistency Checks. ICLR 2026.'
 authors: 'Yu Feng, Nathaniel Weir, Kaj Bostrom, Sam Bayless, Darion Cassel, <strong>Sapana Chaudhary</strong>, Benjamin Kiesl-Reiter, Huzefa Rangwala'
 category: 'Reward Modeling'
 teaser: 'paper-thumbnails/vericot.png'


### PR DESCRIPTION
- Update VeriCoT venue from arXiv preprint to ICLR 2026
- Add new news entries: VeriCoT ICLR acceptance, kernel code optimization paper, serverless RFT launch
- Remove news entries before March 2023

https://claude.ai/code/session_01J7WUw8EnJPUX3u6WbUfgqX